### PR TITLE
Add support to Firefox

### DIFF
--- a/drawing.html
+++ b/drawing.html
@@ -1,4 +1,7 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
 <style>
 body {
     height: 90vh;
@@ -88,6 +91,7 @@ input[type=text], select {
 }
 
 </style>
+</head>
 <body>
 <div class="row">
 <div class="column">

--- a/drawing.html
+++ b/drawing.html
@@ -129,7 +129,7 @@ input[type=text], select {
     </form>
     <h1>Speed</h1>
     <div class="content-div"><select id="speed-picker" onchange="speedChanged()">
-        <option value="0s">Instant</option>
+        <option value="0.001s">Instant</option>
         <option value="0.2s">Fast</option>
         <option value="1s" selected>Normal</option>
         <option value="4s">Slow</option>

--- a/drawing.svg
+++ b/drawing.svg
@@ -1127,19 +1127,22 @@
       }[direction];
 
       const controlPlate = document.getElementById("control-plate");
-      const a = document.createElementNS("http://www.w3.org/2000/svg", "animateTransform");
-      a.setAttribute("attributeName", "transform");
-      a.setAttribute("attributeType", "XML");
-      a.setAttribute("type", "translate");
-      a.setAttribute("dur", dur);
+      const needsAnimationTagAdded = !controlPlate.getElementsByTagName('animateTransform').length;
+      const a = (needsAnimationTagAdded ?
+                 document.createElementNS("http://www.w3.org/2000/svg", "animateTransform") :
+                 controlPlate.getElementsByTagName('animateTransform')[0]);
+      if (needsAnimationTagAdded) {
+          a.setAttribute("attributeName", "transform");
+          a.setAttribute("attributeType", "XML");
+          a.setAttribute("type", "translate");
+          a.setAttribute("keyTimes", "0; 0.5; 1");
+          a.setAttribute("fill", "freeze");
+          controlPlate.appendChild(a);
+      }
+
       a.setAttribute("values", `0 0; ${pos[0]} ${pos[1]}; 0 0`);
-      a.setAttribute("keyTimes", "0; 0.5; 1");
-      a.setAttribute("fill", "freeze");
-      controlPlate.appendChild(a);
-      a.addEventListener("endEvent", () => {
-        controlPlate.removeChild(a);
-        callback();
-      });
+      a.setAttribute("dur", dur);
+      a.addEventListener("endEvent", callback, { once: true });
       a.beginElement();
     };
 
@@ -1165,18 +1168,24 @@
       const newKeyValues = keyValues.split(";").map(v => -(parseFloat(v) + 24 * startAngle)).join(";");
 
       const wheel = document.getElementById(`wheel-${wheelIndex}`);
-      const a = document.createElementNS("http://www.w3.org/2000/svg", "animateTransform");
-      a.setAttribute("attributeName", "transform");
-      a.setAttribute("attributeType", "XML");
-      a.setAttribute("type", "rotate");
-      a.setAttribute("dur", dur);
+      const needsAnimationTagAdded = !wheel.getElementsByTagName('animateTransform').length;
+      const a = (needsAnimationTagAdded ?
+                 document.createElementNS("http://www.w3.org/2000/svg", "animateTransform") :
+                 wheel.getElementsByTagName('animateTransform')[0]);
+      if (needsAnimationTagAdded) {
+          a.setAttribute("attributeName", "transform");
+          a.setAttribute("attributeType", "XML");
+          a.setAttribute("type", "rotate");
+          a.setAttribute("fill", "freeze");
+          wheel.appendChild(a);
+      }
+
+      a.removeAttribute("from");
+      a.removeAttribute("to");
+
       a.setAttribute("values", newKeyValues);
       a.setAttribute("keyTimes", keyTimes);
-      a.setAttribute("fill", "freeze");
-      wheel.appendChild(a);
-      a.addEventListener("endEvent", () => {
-        wheel.removeChild(a);
-      });
+      a.setAttribute("dur", dur);
       a.beginElement();
     };
 
@@ -1232,22 +1241,30 @@
         const resetValue = curValue < -180 ? -360 : 0;
 
         const wheel = document.getElementById(`wheel-${i}`);
-        const a = document.createElementNS("http://www.w3.org/2000/svg", "animateTransform");
-        a.setAttribute("attributeName", "transform");
-        a.setAttribute("attributeType", "XML");
-        a.setAttribute("type", "rotate");
+        const needsAnimationTagAdded = !wheel.getElementsByTagName('animateTransform').length;
+        const a = (needsAnimationTagAdded ?
+                   document.createElementNS("http://www.w3.org/2000/svg", "animateTransform") :
+                   wheel.getElementsByTagName('animateTransform')[0]);
+        if (needsAnimationTagAdded) {
+          a.setAttribute("attributeName", "transform");
+          a.setAttribute("attributeType", "XML");
+          a.setAttribute("type", "rotate");
+          a.setAttribute("fill", "freeze");
+          wheel.appendChild(a);
+        }
+
+        a.removeAttribute("values");
+        a.removeAttribute("keyTimes");
+
         a.setAttribute("dur", dur);
         a.setAttribute("from", curValue);
         a.setAttribute("to", resetValue);
-        a.setAttribute("fill", "freeze");
-        wheel.appendChild(a);
         a.addEventListener("endEvent", () => {
-          wheel.removeChild(a);
           if (i == 0) {
             document.setWheels([0, 0, 0, 0]);
             callback && callback();
           }
-        });
+        }, { once: true });
         a.beginElement();
       };
 
@@ -1256,7 +1273,7 @@
       }
     }
 
-    // Removing or shortening this initial animation makes the thing not work
-    document.reset("1s");
+    // Removing this initial animation makes the thing not work
+    document.reset("0.001s");
   //]]></script>
 </svg>

--- a/drawing.svg
+++ b/drawing.svg
@@ -10,7 +10,6 @@
    width="173.82281mm"
    height="280.37323mm"
    viewBox="0 0 173.82281 280.37323"
-   version="1.1"
    id="svg2379"
    sodipodi:docname="drawing.svg"
    inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07, custom)">


### PR DESCRIPTION
Hello! I stumbled across your visualizer while looking at your **lens** project, and thought it was really neat. Firefox didn't handle timing properly, which is the result of adding/removing the \<animateTransform\> elements, for some reason. These patches hope to address that issue, as well as being able to shorten the initial reset() time.